### PR TITLE
Add if else statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.s
 *.o
 *.out
+*.c

--- a/gen_ir.py
+++ b/gen_ir.py
@@ -120,7 +120,11 @@ class CodeGenVisitor(visit.DFSVisitor):
             # gen last line of else body bb, to jump to next bb
             self.add_line(f"br label %{if_else_end.name}")
 
-        self.main.basic_blocks.append(if_else_end)
+        # is this if-else statment the last in a statement list?
+        last_statement = node.parent.ntype == "statement_list" and \
+            node.parent.children[-1] is node
+        if not last_statement:
+            self.main.basic_blocks.append(if_else_end)
 
     def _out_return(self, node):
         op1 = self.exp_stack.pop()

--- a/gen_ir.py
+++ b/gen_ir.py
@@ -54,7 +54,7 @@ class CodeGenVisitor(visit.DFSVisitor):
     def __init__(self, ast):
         super().__init__(ast)
         self.reg_num = 1
-        self.exp_stack = []
+        self.exp_stack: List[Var] = []
 
         self.main = Function("main", "i32")
         self.block = BasicBlock("entry")

--- a/lexing_rules.py
+++ b/lexing_rules.py
@@ -12,6 +12,8 @@ RULES = [
     SymbolRule("\*", "times"),
     SymbolRule("return", "return"),
     SymbolRule("input", "input"),
+    SymbolRule("if", "if"),
+    SymbolRule("else", "else"),
 
     
     SymbolRule("[a-zA-z]+", "id"),

--- a/lexing_rules.py
+++ b/lexing_rules.py
@@ -15,6 +15,7 @@ RULES = [
     SymbolRule("if", "if"),
     SymbolRule("else", "else"),
     SymbolRule("==", "equality"),
+    SymbolRule(";", "semicolon"),
 
     
     SymbolRule("[a-zA-z]+", "id"),

--- a/lexing_rules.py
+++ b/lexing_rules.py
@@ -14,6 +14,7 @@ RULES = [
     SymbolRule("input", "input"),
     SymbolRule("if", "if"),
     SymbolRule("else", "else"),
+    SymbolRule("==", "equality"),
 
     
     SymbolRule("[a-zA-z]+", "id"),

--- a/notes.md
+++ b/notes.md
@@ -1,8 +1,12 @@
-# inline ASM in llvm ir
+## gen llvm ir from c
+
+`clang -S -emit-llvm sample.c -o sample.ll`
+
+## inline ASM in llvm ir
 
 Learned from [here](http://llvm.org/docs/LangRef.html#inline-assembler-expressions)
 
-## Syscall
+### Syscall
 ```
 %3 = call i32 asm sideeffect "movl $$0x00000000, %edi\0Amovl $$0x00000002, %edx\0Amovl $$0, %eax\0Asyscall\0A", "={ax},{si},~{dirflag},~{fpsr},~{flags}"(i8* %2)
 ```
@@ -44,7 +48,7 @@ syscall syntax [here](https://blog.rchapman.org/posts/Linux_System_Call_Table_fo
 
 remember, we told llvm to put an address into `rsi`, `rsi` is the address of the buffer to write what we read
 
-## gcc
+### gcc
 
 LLVM ir mostly follows gcc extended asm convention? according to llvm docs:
 

--- a/parser.py
+++ b/parser.py
@@ -37,7 +37,7 @@ class Parser:
         self.match("left paren")
         self.match("right paren")
         self.match("left brace")
-        s = self.statement()
+        s = self.statement_list()
         self.match("right brace")
         return ast.ASTNode("main", f, [s])
 
@@ -51,6 +51,7 @@ class Parser:
         if peek.token == "return":
             r = self.match("return")
             e = self.expr()
+            self.match("semicolon")
             return ast.ASTNode("return_exp", r, [e])
         if peek.token == "if":
             i = self.match("if")
@@ -72,7 +73,16 @@ class Parser:
             return ast.ASTNode("if_else", i, [e, l1, l2])
 
     def statement_list(self):
-        raise NotImplementedError()
+        """
+        L -> S L | S
+        assume all statement lists must end if next token is }
+        """
+        statements = []
+        s = self.statement()
+        statements.append(s)
+        while self.peek().token != "right brace":
+            statements.append(self.statement())
+        return ast.ASTNode("statement_list", s.symbol, statements)
 
     def expr(self):
         """

--- a/parser.py
+++ b/parser.py
@@ -52,7 +52,7 @@ class Parser:
             r = self.match("return")
             e = self.expr()
             self.match("semicolon")
-            return ast.ASTNode("return_exp", r, [e])
+            return ast.ASTNode("return", r, [e])
         if peek.token == "if":
             i = self.match("if")
             self.match("left paren")
@@ -68,11 +68,11 @@ class Parser:
                 self.match("right brace")
                 # children are:
                 #  expression condition, if statement list, else statment list
-                return ast.ASTNode("if_else", i, [e, l1, l2])
+                return ast.ASTNode("if_statement", i, [e, l1, l2])
                 
             # children are:
             #  expression condition, if statement list
-            return ast.ASTNode("if_else", i, [e, l1])
+            return ast.ASTNode("if_statement", i, [e, l1])
 
     def statement_list(self):
         """

--- a/parser.py
+++ b/parser.py
@@ -37,18 +37,25 @@ class Parser:
         self.match("left paren")
         self.match("right paren")
         self.match("left brace")
-        e = self.expr()
+        s = self.statement()
         self.match("right brace")
-        return ast.ASTNode("main", f, [e])
+        return ast.ASTNode("main", f, [s])
 
+
+    def statement(self):
+        peek = self.peek()
+        if peek.token == "return":
+            r = self.match("return")
+            e = self.expr()
+            return ast.ASTNode("return_exp", r, [e])
 
     def expr(self):
         """
-        E -> return T
+        E -> T
         """
-        r = self.match("return")
-        e = self.term()
-        return ast.ASTNode("return_exp", r, [e])
+        t = self.term()
+        return t
+        
 
     def term(self):
         """

--- a/parser.py
+++ b/parser.py
@@ -41,19 +41,50 @@ class Parser:
         self.match("right brace")
         return ast.ASTNode("main", f, [s])
 
-
     def statement(self):
+        """
+        S -> return E
+        S -> if (E) { L }
+        S -> if (E) { L } else { L }
+        """
         peek = self.peek()
         if peek.token == "return":
             r = self.match("return")
             e = self.expr()
             return ast.ASTNode("return_exp", r, [e])
+        if peek.token == "if":
+            i = self.match("if")
+            self.match("left paren")
+            e = self.expr()
+            self.match("right paren")
+            self.match("left brace")
+            l1 = self.statement_list()
+            self.match("right brace")
+            l2 = None
+            if self.peek().token == "else":
+                self.match("else")
+                self.match("left brace")
+                l2 = self.statement_list()
+                self.match("right brace")
+            # children are:
+            #  expression condition, if statement list, else statement list
+            #  else statment list could be None
+            return ast.ASTNode("if_else", i, [e, l1, l2])
+
+    def statement_list(self):
+        raise NotImplementedError()
 
     def expr(self):
         """
         E -> T
+        E -> T == T
         """
         t = self.term()
+        peek = self.peek()
+        if peek.token == "equality":
+            e = self.match("equality")
+            t2 = self.term()
+            return ast.ASTNode("equality_exp", e, [t, t2])
         return t
         
 

--- a/parser.py
+++ b/parser.py
@@ -61,16 +61,18 @@ class Parser:
             self.match("left brace")
             l1 = self.statement_list()
             self.match("right brace")
-            l2 = None
             if self.peek().token == "else":
                 self.match("else")
                 self.match("left brace")
                 l2 = self.statement_list()
                 self.match("right brace")
+                # children are:
+                #  expression condition, if statement list, else statment list
+                return ast.ASTNode("if_else", i, [e, l1, l2])
+                
             # children are:
-            #  expression condition, if statement list, else statement list
-            #  else statment list could be None
-            return ast.ASTNode("if_else", i, [e, l1, l2])
+            #  expression condition, if statement list
+            return ast.ASTNode("if_else", i, [e, l1])
 
     def statement_list(self):
         """

--- a/test_input/prog1.ch
+++ b/test_input/prog1.ch
@@ -1,4 +1,4 @@
 
 fn main() {
-	return 5 + 5 * (6 - 4) + input()
+	return 5 + 5 * (6 - 4) + input();
 }

--- a/test_input/prog2.ch
+++ b/test_input/prog2.ch
@@ -1,0 +1,4 @@
+
+fn main() {
+	return 5 == 5
+}

--- a/test_input/prog2.ch
+++ b/test_input/prog2.ch
@@ -3,4 +3,5 @@ fn main() {
 	if (5 == 3) {
 		return 5 + 4;
 	}
+	return 1;
 }

--- a/test_input/prog2.ch
+++ b/test_input/prog2.ch
@@ -1,4 +1,6 @@
 
 fn main() {
-	return 5 == 5
+	if (5 == 3) {
+		return 5 + 4;
+	}
 }

--- a/test_input/prog3.ch
+++ b/test_input/prog3.ch
@@ -5,5 +5,4 @@ fn main() {
 	} else {
 		return 3 - 2;
 	}
-	return 4;
 }

--- a/test_input/prog3.ch
+++ b/test_input/prog3.ch
@@ -1,0 +1,8 @@
+
+fn main() {
+	if (5 == 3) {
+		return 5 + 4;
+	} else {
+		return 3 - 2;
+	}
+}

--- a/test_input/prog3.ch
+++ b/test_input/prog3.ch
@@ -5,4 +5,5 @@ fn main() {
 	} else {
 		return 3 - 2;
 	}
+	return 4;
 }

--- a/visit.py
+++ b/visit.py
@@ -22,7 +22,6 @@ class DFSVisitor:
          but some node types you do
         """
         visit_name = f"_visit_{node.ntype}"
-        print(node.ntype)
         if visit_name in self.methods:
             getattr(self, visit_name)(node)
         else:

--- a/visit.py
+++ b/visit.py
@@ -8,18 +8,36 @@ class DFSVisitor:
         self.visit_node(self.ast)
 
     def visit_node(self, node):
-        in_node_name = "_in_{}".format(node.ntype)
-        out_node_name = "_out_{}".format(node.ntype)
-        if in_node_name in self.methods:
-            getattr(self, in_node_name)(node)
+        """
+        ex, if node.ntype = "foobar"
+
+        if _visit_foobar exists, call that. you're done.
+
+        if it doesn't exist:
+            call _in_foobar
+            call visit_node on all of this nodes children
+            call _out_foobar
+
+        most of the time you don't need _visit_foobar,
+         but some node types you do
+        """
+        visit_name = f"_visit_{node.ntype}"
+        print(node.ntype)
+        if visit_name in self.methods:
+            getattr(self, visit_name)(node)
         else:
-            self.default_in_visit(node)
-        for child in node.children:
-            self.visit_node(child)
-        if out_node_name in self.methods:
-            getattr(self, out_node_name)(node)
-        else:
-            self.default_out_visit(node)
+            in_node_name = "_in_{}".format(node.ntype)
+            out_node_name = "_out_{}".format(node.ntype)
+            if in_node_name in self.methods:
+                getattr(self, in_node_name)(node)
+            else:
+                self.default_in_visit(node)
+            for child in node.children:
+                self.visit_node(child)
+            if out_node_name in self.methods:
+                getattr(self, out_node_name)(node)
+            else:
+                self.default_out_visit(node)
 
     def default_in_visit(self, node):
         print("Entering {}".format(node))


### PR DESCRIPTION
- Currently, its possible to compile a valid cheer program into invalid llvm ir. these cheer programs will fail to compile once type checking is added

- ex:
```
fn main() -> int {
	if (<some expr>) {
		return 5 + 4;
	}
}
```
currently compiles, even though it might not return an int