### PR TITLE
Add local variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 *.c
 *.egg-info/
 *.coverage
+htmlcov/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Cheer is inspired by Rust syntax (but doesn't have the ownership system)
 - [ ] standard library - allocate on the heap
 - [ ] match statements
 - [ ] Some, Ok types
-- [ ] compiler backend: create our own llvm ir -> x86 64 instead of using llc
+- [ ] compiler backend: create own llvm ir -> x86 64 instead of using llc
 - [ ] standard library - garbage collection allocation
 - [ ] optimizations: 
     - [ ] Inline
@@ -37,6 +37,14 @@ Currently requires `llc` and `gcc`
 
 ```
 ./compile.sh test_input/prog2.ch
+```
+
+For some reason the llvm assembler can't assemble the output of llc.
+
+Just generating llvm ir:
+
+```
+python3 cheer/compile.py -i test_input/prog4.ch
 ```
 
 ## Run tests

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Cheer is inspired by Rust syntax (but doesn't have the ownership system)
 
 ## Roadmap / Planned features
 
-- [ ] if/else
-- [ ] local variables
+- [x] if/else
+- [x] local variables
 - [ ] while loop
 - [ ] functions
 - [ ] inline assembly
@@ -29,6 +29,7 @@ Cheer is inspired by Rust syntax (but doesn't have the ownership system)
     - [ ] Constant Fold
     - [ ] Peephole
     - (from `Frances Allen, 1971 - A Catalogue of optimizing transformations`)
+- [ ] self hosted compiler
 
 ## Compiling
 

--- a/cheer/ast.py
+++ b/cheer/ast.py
@@ -16,6 +16,16 @@ class ASTNode:
     def __repr__(self):
         return f"ASTNode<{self.ntype}>"
 
+    def __eq__(self, other):
+        if not isinstance(other, ASTNode):
+            return False
+        return (self.ntype, self.symbol, tuple(self.children)) == \
+            (other.ntype, other.symbol, tuple(other.children))
+
+    def __hash__(self):
+        return hash( (self.ntype, self.symbol, tuple(self.children)) )
+
+
 def gen_ast_digraph(root: ASTNode):
     """
     generate diagram for ast rooted at this node

--- a/cheer/ast.py
+++ b/cheer/ast.py
@@ -13,6 +13,9 @@ class ASTNode:
         for c in self.children:
             c.parent = self
 
+    def __repr__(self):
+        return f"ASTNode<{self.ntype}>"
+
 def gen_ast_digraph(root: ASTNode):
     """
     generate diagram for ast rooted at this node

--- a/cheer/compile.py
+++ b/cheer/compile.py
@@ -6,6 +6,7 @@ from cheer import scanner
 from cheer import parser
 from cheer import gen_ir
 from cheer import ast
+from cheer import type_checker
 
 
 def main(parsed):
@@ -18,7 +19,10 @@ def main(parsed):
     if parsed.verbose:
         print(ast.gen_ast_digraph(ast_root))
 
-    gen_code = gen_ir.CodeGenVisitor(ast_root)
+    tc = type_checker.TCVisitor(ast_root)
+    tc.type_check()
+
+    gen_code = gen_ir.CodeGenVisitor(ast_root, tc.symbol_table)
     gen_code.accept()
 
     oname = parsed.output

--- a/cheer/gen_ir.py
+++ b/cheer/gen_ir.py
@@ -65,6 +65,7 @@ class CodeGenVisitor(visit.DFSVisitor):
         self.reg_num = 0
         self.bb_num = 1
         self.exp_stack: List[Var] = []
+        self.symbol_table = symbol_table
 
         self.main = Function("main", "i32")
         bb = BasicBlock("entry")
@@ -130,6 +131,24 @@ class CodeGenVisitor(visit.DFSVisitor):
         op1 = self.exp_stack.pop()
         self.add_line(f"ret {op1.type} %{op1.name}")
 
+    def _out_var_decl_assign(self, node):
+        ste = self.symbol_table.get(node)
+        op1 = self.exp_stack.pop()
+        ste.ir_name = op1.name
+        self.exp_stack.append(op1)
+
+    def _visit_assignment(self, node):
+        # visit rhs (expression)
+        self.visit_node(node.children[1])
+        # ste for lhs
+        ste = self.symbol_table.get(node.children[0])
+        op1 = self.exp_stack.pop()
+        ste.ir_name = op1.name
+        self.exp_stack.append(op1)
+
+    def _out_var(self, node):
+        ste = self.symbol_table.get(node)
+        self.exp_stack.append(Var(ste.ir_name, node.type))
 
     ###### EXPRESSIONS #######
 

--- a/cheer/gen_ir.py
+++ b/cheer/gen_ir.py
@@ -60,7 +60,7 @@ class Var:
 
 
 class CodeGenVisitor(visit.DFSVisitor):
-    def __init__(self, ast):
+    def __init__(self, ast, symbol_table):
         super().__init__(ast)
         self.reg_num = 0
         self.bb_num = 1

--- a/cheer/lexing_rules.py
+++ b/cheer/lexing_rules.py
@@ -16,7 +16,8 @@ RULES = [
     SymbolRule("else", "else"),
     SymbolRule("==", "equality"),
     SymbolRule(";", "semicolon"),
-
+    SymbolRule("let", "let"),
+    SymbolRule("=", "assign"),
     
     SymbolRule("[a-zA-z]+", "id"),
     SymbolRule("[ \t\n]", "whitespace", add_symbol=False)

--- a/cheer/lexing_rules.py
+++ b/cheer/lexing_rules.py
@@ -18,6 +18,10 @@ RULES = [
     SymbolRule(";", "semicolon"),
     SymbolRule("let", "let"),
     SymbolRule("=", "assign"),
+    SymbolRule(":", "colon"),
+    SymbolRule("i32", "i32"),
+    SymbolRule("bool", "bool"),
+    SymbolRule("true | false", "bool_literal", to_value=lambda x: x == "true"),
     
     SymbolRule("[a-zA-z]+", "id"),
     SymbolRule("[ \t\n]", "whitespace", add_symbol=False)

--- a/cheer/lexing_rules.py
+++ b/cheer/lexing_rules.py
@@ -21,7 +21,7 @@ RULES = [
     SymbolRule(":", "colon"),
     SymbolRule("i32", "i32"),
     SymbolRule("bool", "bool"),
-    SymbolRule("true | false", "bool_literal", to_value=lambda x: x == "true"),
+    SymbolRule(r"true|false", "bool_literal", to_value=lambda x: x == "true"),
     
     SymbolRule("[a-zA-z]+", "id"),
     SymbolRule("[ \t\n]", "whitespace", add_symbol=False)

--- a/cheer/lexing_rules.py
+++ b/cheer/lexing_rules.py
@@ -23,6 +23,6 @@ RULES = [
     SymbolRule("bool", "bool"),
     SymbolRule(r"true|false", "bool_literal", to_value=lambda x: x == "true"),
     
-    SymbolRule("[a-zA-z]+", "id"),
+    SymbolRule(r"[a-zA-z][\w]*", "id"),
     SymbolRule("[ \t\n]", "whitespace", add_symbol=False)
 ]

--- a/cheer/parser.py
+++ b/cheer/parser.py
@@ -118,7 +118,7 @@ class Parser:
             self.match("assign")
             e = self.expr()
             self.match("semicolon")
-            return ASTNode("var_decl_assign", i, [e])
+            return ast.ASTNode("var_decl_assign", i, [e])
         # let id: Ty
         self.match("colon")
         ty = self.type_decl()
@@ -131,8 +131,9 @@ class Parser:
         """
         peek = self.peek()
         valid_type_tokens = ["i32", "bool", "id"]
-        if peek in valid_type_tokens:
-            return self.match(peek)
+        if peek.token in valid_type_tokens:
+            t = self.match(peek.token)
+            return ast.ASTNode(peek.token, t, None)
         self.error(f"Expected a type found: {peek}")
 
     def assign_statement(self):
@@ -191,7 +192,7 @@ class Parser:
 
     def paren(self):
         """
-        P -> I | (E)
+        P -> I | (E) | input | bool
         """
         peek = self.peek()
         if peek.token == "left paren":
@@ -206,6 +207,9 @@ class Parser:
             self.match("left paren")
             self.match("right paren")
             return ast.ASTNode("input_exp", i, None)
+        elif peek.token == "bool_literal":
+            return self.bool_literal()
+        self.error(f"unexpected {peek}")
 
     def int_literal(self):
         sym = self.match("int literal")

--- a/cheer/parser.py
+++ b/cheer/parser.py
@@ -43,9 +43,11 @@ class Parser:
 
     def statement(self):
         """
-        S -> return E
+        S -> return E;
         S -> if (E) { L }
         S -> if (E) { L } else { L }
+        S -> let <id>;
+        S -> <id> = E;
         """
         peek = self.peek()
         if peek.token == "return":
@@ -53,7 +55,7 @@ class Parser:
             e = self.expr()
             self.match("semicolon")
             return ast.ASTNode("return", r, [e])
-        if peek.token == "if":
+        elif peek.token == "if":
             i = self.match("if")
             self.match("left paren")
             e = self.expr()
@@ -73,6 +75,17 @@ class Parser:
             # children are:
             #  expression condition, if statement list
             return ast.ASTNode("if_statement", i, [e, l1])
+        elif peek.token == "let":
+            self.match("let")
+            i = self.match("id")
+            self.match("semicolon")
+            return ast.ASTNode("var_decl", i, None)
+        elif peek.token == "id":
+            self.match("id")
+            e = self.match("assign")
+            ex = self.expr()
+            self.match("semicolon")
+            return ast.ASTNode("assignment", e, [ex])
 
     def statement_list(self):
         """

--- a/cheer/parser.py
+++ b/cheer/parser.py
@@ -140,11 +140,11 @@ class Parser:
         """
         Ass -> id = E
         """
-        self.match("id")
+        lhs = self.var()
         e = self.match("assign")
         ex = self.expr()
         self.match("semicolon")
-        return ast.ASTNode("assignment", e, [ex])
+        return ast.ASTNode("assignment", e, [lhs, ex])
 
     def expr(self):
         """
@@ -192,7 +192,7 @@ class Parser:
 
     def paren(self):
         """
-        P -> I | (E) | input | bool
+        P -> I | (E) | input | bool | Var
         """
         peek = self.peek()
         if peek.token == "left paren":
@@ -209,7 +209,17 @@ class Parser:
             return ast.ASTNode("input_exp", i, None)
         elif peek.token == "bool_literal":
             return self.bool_literal()
+        elif peek.token == "id":
+            return self.var()
+
         self.error(f"unexpected {peek}")
+
+    def var(self):
+        """
+        Var -> id
+        """
+        i = self.match("id")
+        return ast.ASTNode("var", i, None)
 
     def int_literal(self):
         sym = self.match("int literal")

--- a/cheer/scanner.py
+++ b/cheer/scanner.py
@@ -76,12 +76,12 @@ def dummy_tokenize(input_str):
 
 def main():
     rules = [
-        SymbolRule("def", "function def"), 
-        SymbolRule("[a-zA-z]+", "id"),
+        SymbolRule(r"true|false", "bool_literal", to_value=lambda x: x == "true"),
         SymbolRule("[ \n]", "whitespace", add_symbol=False)
     ]
-    with open("test_input/scan.log", "r") as infile:
-        print(scan(infile, rules))
+
+    source = ["true false       true"]
+    tokens = scan(source, rules)
 
 
 if __name__ == "__main__":

--- a/cheer/scanner.py
+++ b/cheer/scanner.py
@@ -2,7 +2,7 @@ import re
 
 
 class SymbolRule:
-    def __init__(self, re, token_name, to_value=lambda _: -1, add_symbol=True):
+    def __init__(self, re, token_name, to_value=lambda _: None, add_symbol=True):
         self.re = re
         self.token_name = token_name
         self.to_value = to_value
@@ -18,7 +18,7 @@ class Symbol:
         self.col = col # column number
 
     def __repr__(self):
-        return "{}<{}> at ({},{})".format(self.token, self.lexeme, self.line, self.col)
+        return f"{self.token}<{self.lexeme}> at ({self.line},{self.col})"
 
     def location(self):
         return f"({self.line}, {self.col}"

--- a/cheer/symbol_table.py
+++ b/cheer/symbol_table.py
@@ -1,10 +1,19 @@
-from cheer import ast
-
+import collections
 from typing import Dict
+
+from cheer import ast
 
 
 class AlreadyCreatedError(Exception):
     pass
+
+
+class Scope:
+    def __init__(self, scope_num):
+        self.scope_num = scope_num
+
+    def __hash__(self):
+        return hash(self.scope_num)
 
 
 class STE:
@@ -24,18 +33,18 @@ class STE:
 class SymTable:
     def __init__(self):
         self.scope = 1
-        self.st: Dict[str, STE] = {}
+        self.st: Dict[Scope, Dict[str, STE]] = collections.defaultdict(dict)
 
-    def create(self, node: ast.ASTNode, been_assigned=False):
+    def create(self, node: ast.ASTNode, scope: Scope, been_assigned=False):
         if node.ntype != "var_decl" and node.ntype != "var_decl_assign":
             raise ValueError(f"expected var type, not {node.ntype}")
         if node.symbol.lexeme in self.st:
             raise AlreadyCreatedError(f"lexeme {node.symbol.lexeme} already exists in this scope")
 
-        self.st[node.symbol.lexeme] = STE(node, been_assigned)
+        self.st[scope][node.symbol.lexeme] = STE(node, been_assigned)
 
-    def get(self, node: ast.ASTNode):
-        return self.st[node.symbol.lexeme]
+    def get(self, node: ast.ASTNode, scope: Scope):
+        return self.st[scope][node.symbol.lexeme]
 
-    def get_type(self, node: ast.ASTNode):
-        return self.st[node.symbol.lexeme].node.type
+    def get_type(self, node: ast.ASTNode, scope: Scope):
+        return self.get(node, scope).node.type

--- a/cheer/symbol_table.py
+++ b/cheer/symbol_table.py
@@ -21,7 +21,10 @@ class Scope:
         self.scope_num = scope_num
 
     def __hash__(self):
-        return hash(self.scope_num)
+        return self.scope_num
+
+    def __eq__(self, other):
+        return self.scope_num == other.scope_num
 
     def __repr__(self):
         return str(self.scope_num)
@@ -39,7 +42,7 @@ class STE:
         self.ir_name = ""
 
     def __repr__(self):
-        return str(f"{self.node}, {self.assigned_scopes}")
+        return str(f"<{self.node}, Scopes: {self.assigned_scopes}>")
 
     def assign_in_scope(self, scope: Scope):
         self.assigned_scopes.add(scope)
@@ -62,7 +65,7 @@ class SymTable:
         if node.ntype != "var_decl" and node.ntype != "var_decl_assign":
             raise ValueError(f"expected var type, not {node.ntype}")
         if node.symbol.lexeme in self.st:
-            raise AlreadyCreatedError(f"lexeme {node.symbol.lexeme} already exists in this scope")
+            raise AlreadyCreatedError(f"lexeme {node.symbol} already exists in this scope")
 
         ste = STE(node)
         self.st[scope_stack[-1]][node.symbol.lexeme] = ste
@@ -78,7 +81,7 @@ class SymTable:
                 # didn't exist in that scope
                 pass
         # tried all scopes in the scope stack and it wasn't in any of them
-        raise NotDeclaredError(f"{node.symbol.lexeme} is not declared in available scopes")
+        raise NotDeclaredError(f"{node.symbol} is not declared in available scopes")
 
     def get_type(self, node: ast.ASTNode, scope_stack: List[Scope]):
         return self.get(node, scope_stack).node.type

--- a/cheer/symbol_table.py
+++ b/cheer/symbol_table.py
@@ -1,10 +1,18 @@
 import collections
-from typing import Dict
+from typing import Dict, List, Set
 
 from cheer import ast
 
 
-class AlreadyCreatedError(Exception):
+class SymbolTableError(Exception):
+    pass
+
+
+class AlreadyCreatedError(SymbolTableError):
+    pass
+
+
+class NotDeclaredError(SymbolTableError):
     pass
 
 
@@ -15,36 +23,65 @@ class Scope:
     def __hash__(self):
         return hash(self.scope_num)
 
+    def __repr__(self):
+        return str(self.scope_num)
+
 
 class STE:
-    def __init__(self, node, been_assigned):
+    def __init__(self, node: ast.ASTNode):
         self.node = node
-        self.been_assigned = been_assigned;
+        # set of scopes this ste was assigned in
+        self.assigned_scopes: Set[Scope] = set()
         self.scope = 0
 
         # for IR gen
         self.reg_num = 0
         self.ir_name = ""
 
-    # name of SSA IR var
-    def get_ssa_new_name(self):
-        return f"{self.node.lexeme}.{self.scope}.{self.reg_num}"
+    def __repr__(self):
+        return str(f"{self.node}, {self.assigned_scopes}")
+
+    def assign_in_scope(self, scope: Scope):
+        self.assigned_scopes.add(scope)
+
+    def is_assigned_in_scope(self, scope_stack: List[Scope]):
+        # search through scope stack and see if its assigned in one of them
+        for scope in scope_stack[::-1]:
+            if scope in self.assigned_scopes:
+                return True
+        return False
+
+
 
 class SymTable:
     def __init__(self):
         self.scope = 1
         self.st: Dict[Scope, Dict[str, STE]] = collections.defaultdict(dict)
 
-    def create(self, node: ast.ASTNode, scope: Scope, been_assigned=False):
+    def create(self, node: ast.ASTNode, scope_stack: List[Scope], assigned_scope=None):
         if node.ntype != "var_decl" and node.ntype != "var_decl_assign":
             raise ValueError(f"expected var type, not {node.ntype}")
         if node.symbol.lexeme in self.st:
             raise AlreadyCreatedError(f"lexeme {node.symbol.lexeme} already exists in this scope")
 
-        self.st[scope][node.symbol.lexeme] = STE(node, been_assigned)
+        ste = STE(node)
+        self.st[scope_stack[-1]][node.symbol.lexeme] = ste
+        if assigned_scope is not None:
+            ste.assign_in_scope(assigned_scope)
 
-    def get(self, node: ast.ASTNode, scope: Scope):
-        return self.st[scope][node.symbol.lexeme]
+    def get(self, node: ast.ASTNode, scope_stack: List[Scope]):
+        # walk scope stack, from youngest child scope to oldest parent scope
+        for scope in scope_stack[::-1]:
+            try:
+                return self.st[scope][node.symbol.lexeme]
+            except KeyError:
+                # didn't exist in that scope
+                pass
+        # tried all scopes in the scope stack and it wasn't in any of them
+        raise NotDeclaredError(f"{node.symbol.lexeme} is not declared in available scopes")
 
-    def get_type(self, node: ast.ASTNode, scope: Scope):
-        return self.get(node, scope).node.type
+    def get_type(self, node: ast.ASTNode, scope_stack: List[Scope]):
+        return self.get(node, scope_stack).node.type
+
+    def __repr__(self):
+        return str(self.st)

--- a/cheer/symbol_table.py
+++ b/cheer/symbol_table.py
@@ -8,8 +8,9 @@ class AlreadyCreatedError(Exception):
 
 
 class STE:
-    def __init__(self, node):
+    def __init__(self, node, been_assigned):
         self.node = node
+        self.been_assigned = been_assigned;
 
 
 class SymTable:
@@ -17,13 +18,16 @@ class SymTable:
         self.scope = 1
         self.st: Dict[str, STE] = {}
 
-    def create(self, node: ast.ASTNode):
+    def create(self, node: ast.ASTNode, been_assigned=False):
         if node.ntype != "var_decl" and node.ntype != "var_decl_assign":
             raise ValueError(f"expected var type, not {node.ntype}")
         if node.symbol.lexeme in self.st:
             raise AlreadyCreatedError(f"lexeme {node.symbol.lexeme} already exists in this scope")
 
-        self.st[node.symbol.lexeme] = STE(node)
+        self.st[node.symbol.lexeme] = STE(node, been_assigned)
 
     def get(self, node: str):
+        return self.st[node]
+
+    def get_type(self, node: str):
         return self.st[node].node.type

--- a/cheer/symbol_table.py
+++ b/cheer/symbol_table.py
@@ -11,7 +11,15 @@ class STE:
     def __init__(self, node, been_assigned):
         self.node = node
         self.been_assigned = been_assigned;
+        self.scope = 0
 
+        # for IR gen
+        self.reg_num = 0
+        self.ir_name = ""
+
+    # name of SSA IR var
+    def get_ssa_new_name(self):
+        return f"{self.node.lexeme}.{self.scope}.{self.reg_num}"
 
 class SymTable:
     def __init__(self):
@@ -26,8 +34,8 @@ class SymTable:
 
         self.st[node.symbol.lexeme] = STE(node, been_assigned)
 
-    def get(self, node: str):
-        return self.st[node]
+    def get(self, node: ast.ASTNode):
+        return self.st[node.symbol.lexeme]
 
-    def get_type(self, node: str):
-        return self.st[node].node.type
+    def get_type(self, node: ast.ASTNode):
+        return self.st[node.symbol.lexeme].node.type

--- a/cheer/symbol_table.py
+++ b/cheer/symbol_table.py
@@ -1,0 +1,29 @@
+from cheer import ast
+
+from typing import Dict
+
+
+class AlreadyCreatedError(Exception):
+    pass
+
+
+class STE:
+    def __init__(self, node):
+        self.node = node
+
+
+class SymTable:
+    def __init__(self):
+        self.scope = 1
+        self.st: Dict[str, STE] = {}
+
+    def create(self, node: ast.ASTNode):
+        if node.ntype != "var_decl" and node.ntype != "var_decl_assign":
+            raise ValueError(f"expected var type, not {node.ntype}")
+        if node.symbol.lexeme in self.st:
+            raise AlreadyCreatedError(f"lexeme {node.symbol.lexeme} already exists in this scope")
+
+        self.st[node.symbol.lexeme] = STE(node)
+
+    def get(self, node: str):
+        return self.st[node].node.type

--- a/cheer/type_checker.py
+++ b/cheer/type_checker.py
@@ -47,6 +47,18 @@ class TCVisitor(visit.DFSVisitor):
         node.type = node.children[0].type
         self.symbol_table.create(node)
 
+    def _out_assignment(self, node):
+        lhs = node.children[0]
+        try:
+            t = self.symbol_table.get(lhs.symbol.lexeme)
+        except KeyError:
+            msg = f"Assignment to variable {lhs.symbol.lexeme} before declaration\n"
+            msg += f"{lhs.symbol}"
+            self.error(msg)
+        if t != node.children[1].type:
+            msg = f"Assignment to {lhs.symbol.lexeme} should be {t} not {node.children[1].type}"
+            self.error(msg)
+
     # assumes children nodes should have matching types
     def op_helper(self, node, valid_types):
         t = node.children[0].type

--- a/cheer/type_checker.py
+++ b/cheer/type_checker.py
@@ -33,13 +33,13 @@ class TCVisitor(visit.DFSVisitor):
 
     def _out_var(self, node):
         try:
-            node.type = self.symbol_table.get_type(node.symbol.lexeme)
+            node.type = self.symbol_table.get_type(node)
         except KeyError:
             msg = f"Use of variable {node.symbol.lexeme} before declaration\n"
             msg += f"{node.symbol}"
             self.error(msg)
 
-        if not self.symbol_table.get(node.symbol.lexeme).been_assigned:
+        if not self.symbol_table.get(node).been_assigned:
             msg = f"Use of variable {node.symbol.lexeme} before assignment\n"
             msg += f"{node.symbol}"
             self.error(msg)
@@ -66,7 +66,7 @@ class TCVisitor(visit.DFSVisitor):
         
         lhs = node.children[0]
         try:
-            t = self.symbol_table.get_type(lhs.symbol.lexeme)
+            t = self.symbol_table.get_type(lhs)
         except KeyError:
             msg = f"Assignment to variable {lhs.symbol.lexeme} before declaration\n"
             msg += f"{lhs.symbol}"
@@ -75,7 +75,7 @@ class TCVisitor(visit.DFSVisitor):
             msg = f"Assignment to {lhs.symbol.lexeme} should be {t} not {node.children[1].type}"
             self.error(msg)
 
-        self.symbol_table.get(lhs.symbol.lexeme).been_assigned = True
+        self.symbol_table.get(lhs).been_assigned = True
 
     # assumes children nodes should have matching types
     def op_helper(self, node, valid_types):

--- a/cheer/type_checker.py
+++ b/cheer/type_checker.py
@@ -6,6 +6,9 @@ class TCVisitor(visit.DFSVisitor):
         super().__init__(ast)
         self.symbol_table = []
 
+    def error(self, msg):
+        raise TypeError(msg)
+
     def type_check(self):
         self.accept()
 
@@ -16,3 +19,45 @@ class TCVisitor(visit.DFSVisitor):
     def default_out_visit(self, node):
         # override
         pass
+
+    def _out_int_literal(self, node):
+        node.type = "i32"
+
+    def _out_bool_literal(self, node):
+        node.type = "bool"
+
+    def _out_var_decl(self, node):
+        node.type = node.children[0].symbol.lexeme
+
+    def _out_var_decl_assign(self, node):
+        node.type = node.children[0].type
+
+    # assumes children nodes should have matching types
+    def op_helper(self, node, valid_types):
+        t = node.children[0].type
+        if valid_types and t not in valid_types:
+            msg = f"Expected {c1} to have one of types: {valid_types}"
+            self.error(msg)
+            return None
+        for c in node.children[1:]:
+            if c.type != t:
+                msg = f"Expected {c} ({c.type}) to have type {t}"
+                self.error(msg)
+                return None
+        return t
+
+    def _out_plus_exp(self, node):
+        t = self.op_helper(node, ["i32"])
+        node.type = t
+
+    def _out_minus_exp(self, node):
+        t = self.op_helper(node, ["i32"])
+        node.type = t
+
+    def _out_times_exp(self, node):
+        t = self.op_helper(node, ["i32"])
+        node.type = t
+
+    def _out_equality_exp(self, node):
+        _ = self.op_helper(node, None)
+        node.type = "bool"

--- a/cheer/type_checker.py
+++ b/cheer/type_checker.py
@@ -2,13 +2,17 @@ from cheer import visit
 from cheer import symbol_table
 
 
+class TypeCheckingError(Exception):
+    pass
+
+
 class TCVisitor(visit.DFSVisitor):
     def __init__(self, ast):
         super().__init__(ast)
         self.symbol_table = symbol_table.SymTable()
 
     def error(self, msg):
-        raise TypeError(msg)
+        raise TypeCheckingError(msg)
 
     def type_check(self):
         self.accept()
@@ -28,7 +32,12 @@ class TCVisitor(visit.DFSVisitor):
         node.type = "bool"
 
     def _out_var(self, node):
-        node.type = self.symbol_table.get(node.symbol.lexeme)
+        try:
+            node.type = self.symbol_table.get(node.symbol.lexeme)
+        except KeyError:
+            msg = f"Use of variable {node.symbol.lexeme} before declaration\n"
+            msg += f"{node.symbol}"
+            self.error(msg)
 
     def _out_var_decl(self, node):
         node.type = node.children[0].symbol.lexeme

--- a/cheer/type_checker.py
+++ b/cheer/type_checker.py
@@ -16,6 +16,7 @@ class TCVisitor(visit.DFSVisitor):
 
     def type_check(self):
         self.accept()
+        return True
 
     def default_in_visit(self, node):
         # override
@@ -39,6 +40,7 @@ class TCVisitor(visit.DFSVisitor):
             msg += f"{node.symbol}"
             self.error(msg)
 
+        print(node.symbol)
         if not self.symbol_table.get(node).been_assigned:
             msg = f"Use of variable {node.symbol.lexeme} before assignment\n"
             msg += f"{node.symbol}"

--- a/cheer/type_checker.py
+++ b/cheer/type_checker.py
@@ -39,6 +39,9 @@ class TCVisitor(visit.DFSVisitor):
             msg += f"{node.symbol}"
             self.error(msg)
 
+    def _out_input_exp(self, node):
+        node.type = "i32";
+
     def _out_var_decl(self, node):
         node.type = node.children[0].symbol.lexeme
         self.symbol_table.create(node)

--- a/cheer/type_checker.py
+++ b/cheer/type_checker.py
@@ -1,10 +1,11 @@
 from cheer import visit
+from cheer import symbol_table
 
 
 class TCVisitor(visit.DFSVisitor):
     def __init__(self, ast):
         super().__init__(ast)
-        self.symbol_table = []
+        self.symbol_table = symbol_table.SymTable()
 
     def error(self, msg):
         raise TypeError(msg)
@@ -26,17 +27,22 @@ class TCVisitor(visit.DFSVisitor):
     def _out_bool_literal(self, node):
         node.type = "bool"
 
+    def _out_var(self, node):
+        node.type = self.symbol_table.get(node.symbol.lexeme)
+
     def _out_var_decl(self, node):
         node.type = node.children[0].symbol.lexeme
+        self.symbol_table.create(node)
 
     def _out_var_decl_assign(self, node):
         node.type = node.children[0].type
+        self.symbol_table.create(node)
 
     # assumes children nodes should have matching types
     def op_helper(self, node, valid_types):
         t = node.children[0].type
         if valid_types and t not in valid_types:
-            msg = f"Expected {c1} to have one of types: {valid_types}"
+            msg = f"Expected {node.children[0]} ({t}) to have one of types: {valid_types}"
             self.error(msg)
             return None
         for c in node.children[1:]:

--- a/cheer/type_checker.py
+++ b/cheer/type_checker.py
@@ -1,0 +1,10 @@
+from cheer import visit
+
+
+class TCVisitor(visit.DFSVisitor):
+    def __init__(self, ast):
+        super().__init__(ast)
+        self.symbol_table = []
+
+    def type_check(self):
+    	self.accept()

--- a/cheer/type_checker.py
+++ b/cheer/type_checker.py
@@ -1,3 +1,4 @@
+from typing import List
 from cheer import visit
 from cheer import symbol_table
 
@@ -6,10 +7,20 @@ class TypeCheckingError(Exception):
     pass
 
 
+class Scope:
+    def __init__(self, scope_num):
+        self.scope_num = scope_num
+
+    def __hash__(self):
+        return hash(Self.scope_num)
+
+
 class TCVisitor(visit.DFSVisitor):
     def __init__(self, ast):
         super().__init__(ast)
         self.symbol_table = symbol_table.SymTable()
+        self.scope_num = 0
+        self.scope_stack: List[Scope] = []
 
     def error(self, msg):
         raise TypeCheckingError(msg)
@@ -25,6 +36,14 @@ class TCVisitor(visit.DFSVisitor):
     def default_out_visit(self, node):
         # override
         pass
+
+    def _in_statement_list(self, node):
+        new_scope = Scope(self.scope_num)
+        self.scope_num += 1
+        self.scope_stack.append(new_scope)
+
+    def _out_statement_list(self, node):
+        self.scope_stack.pop()
 
     def _out_int_literal(self, node):
         node.type = "i32"

--- a/cheer/type_checker.py
+++ b/cheer/type_checker.py
@@ -7,4 +7,12 @@ class TCVisitor(visit.DFSVisitor):
         self.symbol_table = []
 
     def type_check(self):
-    	self.accept()
+        self.accept()
+
+    def default_in_visit(self, node):
+        # override
+        pass
+
+    def default_out_visit(self, node):
+        # override
+        pass

--- a/test_input/prog4.ch
+++ b/test_input/prog4.ch
@@ -1,0 +1,10 @@
+
+fn main() {
+	let x;
+	x = 5 + 4;
+	if (5 == 3) {
+		return 5 + 4;
+	} else {
+		return 3 - 2;
+	}
+}

--- a/test_input/prog4.ch
+++ b/test_input/prog4.ch
@@ -1,7 +1,7 @@
 
 fn main() {
     let x: i32;
-    x = 5 + 4;
+    x = input();
     let y = 6 == 5 + 1;
     y = false;
     if (5 == 3) {

--- a/test_input/prog4.ch
+++ b/test_input/prog4.ch
@@ -1,9 +1,8 @@
 
 fn main() {
-    let x: i32;
-    x = input();
-    let y = 6 == 5 + 1;
-    y = false;
+    let x = 4;
+    let y = x + 1;
+    y = y + y;
     if (5 == 3) {
         return 5 + 4;
     } else {

--- a/test_input/prog4.ch
+++ b/test_input/prog4.ch
@@ -3,6 +3,7 @@ fn main() {
     let x: i32;
     x = 5 + 4;
     let y = 6 == 5 + 1;
+    y = y == false;
     if (5 == 3) {
         return 5 + 4;
     } else {

--- a/test_input/prog4.ch
+++ b/test_input/prog4.ch
@@ -3,7 +3,7 @@ fn main() {
     let x: i32;
     x = 5 + 4;
     let y = 6 == 5 + 1;
-    y = y == false;
+    y = y + z;
     if (5 == 3) {
         return 5 + 4;
     } else {

--- a/test_input/prog4.ch
+++ b/test_input/prog4.ch
@@ -1,10 +1,11 @@
 
 fn main() {
-	let x;
-	x = 5 + 4;
-	if (5 == 3) {
-		return 5 + 4;
-	} else {
-		return 3 - 2;
-	}
+    let x: i32;
+    x = 5 + 4;
+    let y = 6 == 5 + 1;
+    if (5 == 3) {
+        return 5 + 4;
+    } else {
+        return 3 - 2;
+    }
 }

--- a/test_input/prog4.ch
+++ b/test_input/prog4.ch
@@ -3,7 +3,7 @@ fn main() {
     let x = 4;
     let y = x + 1;
     y = y + y;
-    if (5 == 3) {
+    if (y - 4 == 0) {
         return 5 + 4;
     } else {
         return 3 - 2;

--- a/test_input/prog4.ch
+++ b/test_input/prog4.ch
@@ -3,7 +3,7 @@ fn main() {
     let x: i32;
     x = 5 + 4;
     let y = 6 == 5 + 1;
-    y = y + z;
+    y = false;
     if (5 == 3) {
         return 5 + 4;
     } else {

--- a/test_input/prog5.ch
+++ b/test_input/prog5.ch
@@ -1,8 +1,9 @@
 
 fn main() {
     let x = input();
-    let y: i32;
-    if (x == 3) {
+    let y = 0;
+    let ascii_3 = 51;
+    if (x == ascii_3) {
         y = 2 * x;
     } else {
         return 3 - 2;

--- a/test_input/prog5.ch
+++ b/test_input/prog5.ch
@@ -1,0 +1,12 @@
+
+fn main() {
+    let x = input();
+    let y: i32;
+    if (x == 3) {
+        y = 2 * x;
+    } else {
+        return 3 - 2;
+    }
+    y = y + 4;
+    return y;
+}

--- a/test_input/prog6.ch
+++ b/test_input/prog6.ch
@@ -1,0 +1,10 @@
+fn main() {
+    let y: i32;
+    let x = 1;
+    if (input() == 51) {
+        let x = 2;
+        return x;
+    }
+    y = x * 4;
+    return y;
+}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,22 @@
+import pytest
+from cheer import ast, scanner, parser, lexing_rules
+
+
+def test_parse1():
+    prog = ["3 * (2 + 8) - 9 * 11;"]
+    tokens = scanner.scan(prog, lexing_rules.RULES)
+    p = parser.Parser(tokens)
+    root = p.expr()
+
+    a3 = ast.ASTNode("int_literal", scanner.Symbol("int literal", "3", 3, 1, 1), None)
+    a2 = ast.ASTNode("int_literal", scanner.Symbol("int literal", "2", 2, 1, 6), None)
+    a8 = ast.ASTNode("int_literal", scanner.Symbol("int literal", "8", 8, 1, 10), None)
+    a9 = ast.ASTNode("int_literal", scanner.Symbol("int literal", "9", 9, 1, 15), None)
+    a11 = ast.ASTNode("int_literal", scanner.Symbol("int literal", "11", 11, 1, 19), None)
+
+    plus = ast.ASTNode("plus_exp", scanner.Symbol("plus", "+", None, 1,  8), [a2, a8])
+    times1 = ast.ASTNode("times_exp", scanner.Symbol("times", "*", None, 1,  3), [a3, plus])
+    times2 = ast.ASTNode("times_exp", scanner.Symbol("times", "*", None, 1,  17), [a9, a11])
+    minus = ast.ASTNode("minus_exp", scanner.Symbol("minus", "-", None, 1,  13), [times1, times2])
+
+    assert root == minus

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -10,12 +10,12 @@ def test_scanner():
     with open("test_input/scan.log", "r") as infile:
         tokens = scanner.scan(infile, rules)
     expected = [
-        scanner.Symbol("function def", "def", -1, 1, 1),
-        scanner.Symbol("id", "asdf", -1, 1, 5),
-        scanner.Symbol("id", "popo", -1, 2, 1),
-        scanner.Symbol("id", "asdf", -1, 2, 6),
-        scanner.Symbol("function def", "def", -1, 2, 11),
-        scanner.Symbol("id", "defdef", -1, 2, 15),
+        scanner.Symbol("function def", "def", None, 1, 1),
+        scanner.Symbol("id", "asdf", None, 1, 5),
+        scanner.Symbol("id", "popo", None, 2, 1),
+        scanner.Symbol("id", "asdf", None, 2, 6),
+        scanner.Symbol("function def", "def", None, 2, 11),
+        scanner.Symbol("id", "defdef", None, 2, 15),
     ]
 
     assert expected == tokens

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -19,3 +19,20 @@ def test_scanner():
     ]
 
     assert expected == tokens
+
+def test_scanner_to_value():
+    rules = [
+        scanner.SymbolRule(r"true|false", "bool_literal", to_value=lambda x: x == "true"),
+        scanner.SymbolRule("[ \n]", "whitespace", add_symbol=False)
+    ]
+
+    source = ["true false       true"]
+    tokens = scanner.scan(source, rules)
+    print(tokens)
+    expected = [
+        scanner.Symbol("bool_literal", "true", True, 1, 1),
+        scanner.Symbol("bool_literal", "false", False, 1, 6),
+        scanner.Symbol("bool_literal", "true", True, 1, 18),
+    ]
+
+    assert expected == tokens

--- a/tests/test_type_checker.py
+++ b/tests/test_type_checker.py
@@ -1,0 +1,42 @@
+import pytest
+from cheer import ast, type_checker, scanner, parser, lexing_rules
+
+def tc_test_helper(prog):
+    tokens = scanner.scan(prog, lexing_rules.RULES)
+    p = parser.Parser(tokens)
+    return p
+    
+
+def test_plus_exp_invalid():
+    prog = ["return true + 1;"]
+    par = tc_test_helper(prog)
+    root = par.statement()
+    tc = type_checker.TCVisitor(root)
+    with pytest.raises(type_checker.TypeCheckingError):
+        tc.type_check()
+
+def test_plus_exp_valid():
+    prog = ["let x = 1 + 2;"]
+    par = tc_test_helper(prog)
+    root = par.statement()
+    tc = type_checker.TCVisitor(root)
+    assert tc.type_check() is True
+
+def test_use_before_assign():
+    prog = """
+        fn main() {
+            let y: i32;
+            if (input() == 1) {
+                y = 2;
+            } else {
+                return 0;
+            }
+            return y;
+        }
+    """
+    prog = prog.split("\n")
+    par = tc_test_helper(prog)
+    root = par.start()
+    tc = type_checker.TCVisitor(root)
+    with pytest.raises(type_checker.TypeCheckingError):
+        tc.type_check()

--- a/tests/test_type_checker.py
+++ b/tests/test_type_checker.py
@@ -1,5 +1,5 @@
 import pytest
-from cheer import ast, type_checker, scanner, parser, lexing_rules
+from cheer import ast, type_checker, scanner, parser, lexing_rules, symbol_table
 
 def tc_test_helper(prog):
     tokens = scanner.scan(prog, lexing_rules.RULES)
@@ -20,6 +20,7 @@ def test_plus_exp_valid():
     par = tc_test_helper(prog)
     root = par.statement()
     tc = type_checker.TCVisitor(root)
+    tc.scope_stack.append(symbol_table.Scope(0))
     assert tc.type_check() is True
 
 def test_use_before_assign():
@@ -40,3 +41,55 @@ def test_use_before_assign():
     tc = type_checker.TCVisitor(root)
     with pytest.raises(type_checker.TypeCheckingError):
         tc.type_check()
+
+def test_use_invalid_scope():
+    prog = """
+        fn main() {
+            let y: i32;
+            let x: i32;
+            if (input() == 1) {
+                let x = 2;
+            }
+            y = x + 0;
+        }
+    """
+    prog = prog.split("\n")
+    par = tc_test_helper(prog)
+    root = par.start()
+    tc = type_checker.TCVisitor(root)
+    with pytest.raises(type_checker.TypeCheckingError):
+        tc.type_check()
+
+def test_valid_shadowing_scope():
+    prog = """
+        fn main() {
+            let y: i32;
+            let x = 1;
+            if (input() == 1) {
+                let x = 2;
+                return x;
+            }
+            y = x * 4;
+        }
+    """
+    prog = prog.split("\n")
+    par = tc_test_helper(prog)
+    root = par.start()
+    tc = type_checker.TCVisitor(root)
+    assert tc.type_check() is True
+
+def test_use_parent_scope():
+    prog = """
+        fn main() {
+            let y = 4;
+            if (input() == 1) {
+                y = 1;
+            }
+            return y;
+        }
+    """
+    prog = prog.split("\n")
+    par = tc_test_helper(prog)
+    root = par.start()
+    tc = type_checker.TCVisitor(root)
+    assert tc.type_check() is True


### PR DESCRIPTION
Adds local variables.

Can declare ahead of use, but must have a type, like:
```
let x: i32;
```

or declare and assign and omit the type (will be inferred from expression)
```
let y = input();
```